### PR TITLE
prefer raw altitude value rather than computed

### DIFF
--- a/src/mapillary_downloader/exif_writer.py
+++ b/src/mapillary_downloader/exif_writer.py
@@ -85,8 +85,8 @@ def write_exif_to_image(image_path, metadata):
             exif_dict["0th"][piexif.ImageIFD.DateTime] = datetime_bytes
             exif_dict["Exif"][piexif.ExifIFD.DateTimeOriginal] = datetime_bytes
             exif_dict["Exif"][piexif.ExifIFD.DateTimeDigitized] = datetime_bytes
-            exif_dict["Exif"][piexif.ExifIFD.SubSecTimeOriginal] = ('000'+str(metadata["captured_at"] % 1000))[-3:]
-            exif_dict["Exif"][piexif.ExifIFD.SubSecTimeDigitized] = ('000'+str(metadata["captured_at"] % 1000))[-3:]
+            exif_dict["Exif"][piexif.ExifIFD.SubSecTimeOriginal] = ("000" + str(metadata["captured_at"] % 1000))[-3:]
+            exif_dict["Exif"][piexif.ExifIFD.SubSecTimeDigitized] = ("000" + str(metadata["captured_at"] % 1000))[-3:]
 
         # GPS data - prefer computed_geometry over geometry
         geometry = metadata.get("computed_geometry") or metadata.get("geometry")
@@ -101,8 +101,8 @@ def write_exif_to_image(image_path, metadata):
             exif_dict["GPS"][piexif.GPSIFD.GPSLongitude] = decimal_to_dms(lon)
             exif_dict["GPS"][piexif.GPSIFD.GPSLongitudeRef] = b"E" if lon >= 0 else b"W"
 
-        # GPS Altitude - prefer computed_altitude over altitude
-        altitude = metadata.get("computed_altitude") or metadata.get("altitude")
+        # GPS Altitude - prefer raw altitude (photogrammetry can't compute elevation)
+        altitude = metadata.get("altitude") or metadata.get("computed_altitude")
         if altitude is not None:
             altitude_val = int(abs(altitude) * 100)
             logger.debug(f"Raw altitude value: {altitude}, calculated: {altitude_val}")

--- a/tests/test_exif_writer.py
+++ b/tests/test_exif_writer.py
@@ -132,7 +132,7 @@ def test_write_exif_to_image_compass(tmp_path):
 
 
 def test_write_exif_uses_computed_values(tmp_path):
-    """Test that computed values are preferred over originals."""
+    """Test computed value preferences (geometry/compass: computed, altitude: raw)."""
     img = Image.new("RGB", (100, 100), color="yellow")
     image_path = tmp_path / "test.jpg"
     img.save(image_path)
@@ -157,9 +157,9 @@ def test_write_exif_uses_computed_values(tmp_path):
     lat_dms = exif_dict["GPS"][piexif.GPSIFD.GPSLatitude]
     assert lat_dms[0][0] == 2  # 2 degrees
 
-    # Should use computed_altitude (200) not altitude (100)
+    # Should use raw altitude (100) not computed_altitude (200) - photogrammetry can't compute elevation
     altitude = exif_dict["GPS"][piexif.GPSIFD.GPSAltitude]
-    assert altitude[0] == 20000  # 200 * 100
+    assert altitude[0] == 10000  # 100 * 100
 
     # Should use computed_compass_angle (180) not compass_angle (90)
     direction = exif_dict["GPS"][piexif.GPSIFD.GPSImgDirection]


### PR DESCRIPTION
Mapillary's computed location and bearing have been proven good, but as per #1, it looks like the photogrammetry models aren't so accurate for altitude. They probably don't do much with it much anyway being projected onto a map. So we'll prefer the GPS altitude if we have it, rather than the computed value.

Closes #1 